### PR TITLE
fix for django 2 renaming of _format_value()

### DIFF
--- a/bootstrap_datepicker/widgets.py
+++ b/bootstrap_datepicker/widgets.py
@@ -115,7 +115,7 @@ class DatePicker(DateTimeInput):
         input_attrs = self.build_attrs(attrs, extra_attrs)
         if value != '':
             # Only add the 'value' attribute if a value is non-empty.
-            input_attrs['value'] = force_text(self._format_value(value))
+            input_attrs['value'] = force_text(self.format_value(value))
         input_attrs = {key: conditional_escape(val) for key, val in input_attrs.items()}
         if not self.picker_id:
             self.picker_id = (input_attrs.get('id', '') + '_pickers').replace(' ', '_')


### PR DESCRIPTION
Fixes #9  (error: 'DatePicker' object has no attribute '_format_value')