### PR TITLE
WIP Django2.0 Compatibility

### DIFF
--- a/bootstrap_datepicker/widgets.py
+++ b/bootstrap_datepicker/widgets.py
@@ -115,7 +115,7 @@ class DatePicker(DateTimeInput):
         input_attrs = self.build_attrs(attrs, extra_attrs)
         if value != '':
             # Only add the 'value' attribute if a value is non-empty.
-            input_attrs['value'] = force_text(self._format_value(value))
+            input_attrs['value'] = force_text(self.format_value(value))
         input_attrs = {key: conditional_escape(val) for key, val in input_attrs.items()}
         if not self.picker_id:
             self.picker_id = (input_attrs.get('id', '') + '_pickers').replace(' ', '_')


### PR DESCRIPTION
Fix Django >= 2.0 compatibility.
Method name '_format_value' from django.forms.widgets does not exists anymore. The error:
AttributeError: 'DatePicker' object has no attribute '_format_value'
was rised when using Django >= 2.0

See
https://github.com/django/django/blob/1.11.10/django/forms/widgets.py#L162
https://github.com/django/django/blob/2.0/django/forms/widgets.py

IMPORTANT: More testing is needed to ensure backward compatibility with Django <= 1.10